### PR TITLE
feat: mysqlの環境構築

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tmp
+docker/mysql/data

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ ENV_LOCAL = $(shell cat env.local)
 
 .PHONY: run
 run:
-	$(ENV_LOCAL) docker-compose -f docker/docker-compose.yml up
+	$(ENV_LOCAL) docker-compose up
 
 .PHONY: re-run
 re-run:
-	$(ENV_LOCAL) docker-compose -f docker/docker-compose.yml up --build
+	$(ENV_LOCAL) docker-compose up --build

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+ENV_LOCAL = $(shell cat env.local)
+
 .PHONY: run
 run:
-	docker compose -f docker/docker-compose.yml up
+	$(ENV_LOCAL) docker-compose -f docker/docker-compose.yml up
 
 .PHONY: re-run
 re-run:
-	docker compose -f docker/docker-compose.yml up --build
+	$(ENV_LOCAL) docker-compose -f docker/docker-compose.yml up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ version: "3"
 services:
   app:
     build:
-      context: ../
-      dockerfile: docker/app/local/Dockerfile
+      context: .
+      dockerfile: ./docker/app/local/Dockerfile
     volumes:
-      - ../:/go/src/github.com/CA22-game-creators/cookingbomb-server
+      - ./:/go/src/github.com/CA22-game-creators/cookingbomb-server
     restart: always
     tty: true
     ports:
@@ -21,8 +21,8 @@ services:
       - MYSQL_USER
       - MYSQL_PASSWORD
     volumes:
-      - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf
-      - ./mysql/data:/var/lib/mysql
+      - ./docker/mysql/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./docker/mysql/data:/var/lib/mysql
     restart: always
     ports:
       - "3306:3306"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,3 +10,19 @@ services:
     tty: true
     ports:
       - "8080:8080"
+    depends_on:
+      - mysql
+
+  mysql:
+    image: mysql:8.0
+    environment:
+      - MYSQL_ROOT_PASSWORD
+      - MYSQL_DATABASE
+      - MYSQL_USER
+      - MYSQL_PASSWORD
+    volumes:
+      - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./mysql/data:/var/lib/mysql
+    restart: always
+    ports:
+      - "3306:3306"

--- a/docker/mysql/my.cnf
+++ b/docker/mysql/my.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+default_authentication_plugin=mysql_native_password
+character-set-server=utf8mb4
+collation-server=utf8mb4_bin
+
+[mysql]
+default-character-set=utf8mb4
+
+[client]
+default-character-set=utf8mb4

--- a/env.local
+++ b/env.local
@@ -1,0 +1,4 @@
+MYSQL_ROOT_PASSWORD=password
+MYSQL_DATABASE=cooking_bomb
+MYSQL_USER=user
+MYSQL_PASSWORD=password


### PR DESCRIPTION
## About
mysqlをローカルで環境構築

## Background
開発用のDBが欲しかったから

## Details
- mysql:8.0をdocker-composeで起動
- ユーザ名・データベース名などは`env.local`環境変数で指定、Makefileでそれを引用し、docker-composeに渡している
- `docker/mysql/data/`は前回までのデータ履歴を残し、次立ち上げた時も引き継げるようにしている。ignored
- `docker/mysql/my.cnf`では、mysqlの設定をしている。
-> 文字セットをutf8mb4に設定し[寿司ビール問題に対応](https://techracho.bpsinc.jp/hachi8833/2020_11_26/25044)
-> Collactionをutf8mb4_binに設定し、[文字列を厳密に区別可能に](https://qiita.com/tfunato/items/e48ad0a37b8244a788f6)
-> [v8.0から追加された認証方法を前のに戻す](https://qiita.com/RayDoe/items/baf53818ec8e44d4d148#mysql80%E3%81%AE%E6%96%B0%E6%A9%9F%E8%83%BD%E8%BF%BD%E5%8A%A0%E3%81%AE%E3%81%8A%E3%81%97%E3%82%89%E3%81%9B)

## Remarks
- 設定ファイルとか難しいから助言・気になった所あれば欲しいですmm
- 割と[comphor-](https://github.com/camphor-/relaym-server)参考

## Preview
- `make run`して、dbサーバーにアクセスできる
<img width="1111" alt="スクリーンショット 2021-04-26 2 39 53" src="https://user-images.githubusercontent.com/38310693/116003378-b03b7c80-a638-11eb-8095-f893be470e4a.png">
