### PR TITLE
feat: skeemaでDBのマイグレーションを行う

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,7 @@ run:
 .PHONY: re-run
 re-run:
 	$(ENV_LOCAL) docker-compose up --build
+
+.PHONY: migration
+migration:
+	$(ENV_LOCAL) sh ./infrastructure/mysql/schemas/migrator.sh

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,6 @@ run:
 re-run:
 	$(ENV_LOCAL) docker-compose up --build
 
-.PHONY: migration
-migration:
+.PHONY: migrate
+migrate:
 	$(ENV_LOCAL) sh ./infrastructure/mysql/schemas/migrator.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,4 +25,4 @@ services:
       - ./docker/mysql/data:/var/lib/mysql
     restart: always
     ports:
-      - "3306:3306"
+      - "13306:3306"

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,32 @@
+# データベースについて
+
+## スキーマの管理
+
+migration ツールには[skeema](https://github.com/skeema/skeema)を採用した
+
+### 特徴
+
+- 現在の DB 状態を sql ファイルに記載でき、差分を積み上げる[golang-migrate](https://github.com/golang-migrate/migrate)などより可視性が高い
+- sql ファイルと DB で相互に反映し合う
+
+### 使い方
+
+[インストール](https://www.skeema.io/download/)
+
+- コードと DB の diff を確認する
+
+```
+$ skeema diff local -p${MYSQL_ROOT_PASSWORD}
+```
+
+- コードを DB に反映する
+
+```
+$ skeema push local -p${MYSQL_ROOT_PASSWORD}
+```
+
+- DB をコードに反映する
+
+```
+$ skeema pull local -p${MYSQL_ROOT_PASSWORD}
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,3 +13,10 @@ Docker を[ここ](https://www.docker.com/get-started)からインストール
 ```
 $ make run
 ```
+
+## CLI で用いる Go ライブラリ
+
+### Skeema
+
+- マイグレーションツール
+- [インストール](https://www.skeema.io/download/)

--- a/infrastructure/mysql/schemas/.skeema
+++ b/infrastructure/mysql/schemas/.skeema
@@ -1,5 +1,6 @@
 default-character-set=utf8mb4
 default-collation=utf8mb4_bin
+generator=skeema:1.5.0-community
 schema=cooking_bomb
 
 [local]

--- a/infrastructure/mysql/schemas/.skeema
+++ b/infrastructure/mysql/schemas/.skeema
@@ -1,0 +1,9 @@
+default-character-set=utf8mb4
+default-collation=utf8mb4_bin
+schema=cooking_bomb
+
+[local]
+flavor=mysql:8.0
+host=127.0.0.1
+port=13306
+user=root

--- a/infrastructure/mysql/schemas/migrator.sh
+++ b/infrastructure/mysql/schemas/migrator.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+skeema diff local -p$MYSQL_ROOT_PASSWORD
+
+read -p "Migrateしますか？ (y/n) :" YN
+if [ "${YN}" = "y" ]; then
+  skeema push local -p$MYSQL_ROOT_PASSWORD
+else
+  echo "bye!";
+fi

--- a/infrastructure/mysql/schemas/users.sql
+++ b/infrastructure/mysql/schemas/users.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `users` (
-  `id` char(26) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザULID',
-  `name` varchar(255) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザ名',
+  `id` char(26) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザーULID',
+  `name` varchar(255) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザー名',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='ユーザ';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='ユーザー';

--- a/infrastructure/mysql/schemas/users.sql
+++ b/infrastructure/mysql/schemas/users.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `users` (
+  `id` char(26) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザULID',
+  `name` varchar(255) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザ名',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='ユーザ';


### PR DESCRIPTION
## Issues
#19 
## About
skeemaでDBのマイグレーションを行う
## Background
開発(本番)環境でDBのテーブル構成を管理しやすくしたかったから
## Details
- migrationツールには[skeema](https://github.com/skeema/skeema)を採用
DBの差分を積み重ねる[golang-migration](https://github.com/golang-migrate/migrate)などと異なり、見た目で完成DB図を想像できるから
- とりあえずULIDを識別子にもった名前付きのユーザテーブルを作成
- `$ make migrate`で`infrastructure/mysql/schemas/**.sql`を反映するCLIが走る
## Remarks
- DBのport番号がローカルのmysqlPortとかぶるため13306に変更した
- 将来的にDDDの構成にしたいので、DB情報に関するschemaなどはinfrastructure層に置いた
- ULIDは自前でID付与できるUUIDの進化版みたいなやつで、UUIDよりも文字数が少ない上にソート可能というメリットがある
([DDDは一般的に識別子をDBのautoincreamentに委ねない場合が多い](https://nrslib.com/bottomup-ddd-2/#outline__2_5)
## Preview
```
$ make migrate
```
実際のDBと`infrastructure/mysql/schemas/**.sql`のdiffを表示した後、「y」で反映させる。
<img width="1326" alt="スクリーンショット 2021-04-30 14 32 57" src="https://user-images.githubusercontent.com/38310693/116652833-f722cc80-a9c0-11eb-8092-621c023bf776.png">
<img width="976" alt="スクリーンショット 2021-04-30 9 41 33" src="https://user-images.githubusercontent.com/38310693/116654167-9648c380-a9c3-11eb-9186-701917ec16d7.png">

## TODO
- initdataの注入コマンド