### PR TITLE
refactor: lintコマンド実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,8 @@ run:
 .PHONY: re-run
 re-run:
 	$(ENV_LOCAL) docker-compose up --build
+
+.PHONY: lint
+lint:
+	go mod tidy
+	golangci-lint run --enable=golint,gosec,prealloc,gocognit

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,3 +20,8 @@ $ make run
 
 - マイグレーションツール
 - [インストール](https://www.skeema.io/download/)
+
+### golangci-lint
+
+- Go の Linter 詰め合わせ
+- [インストール](https://golangci-lint.run/usage/install/#local-installation)


### PR DESCRIPTION
## Issues
None
## About
lintコマンド実装
## Background
git push前に記法・エラー・セキュリティ周りを確認したいため
## Details
- `make lint`でgoModuleの整理・golangcliの実行
- golangcliはデフォルトではdisableされている以下4linterもenableに

```
golint: 基本的な記法ミス
gosec: セキュリティの脆弱性検知
prealloc: appendの非効率なアロケートなど検知
gocognit: 無駄に複雑な記法
```

## Remarks
- [install](https://golangci-lint.run/usage/install/#local-installation)

