### PR TITLE
feat: Userテーブルに認証用のauth_tokenカラムをmigration

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -19,7 +19,7 @@ migration ツールには[skeema](https://github.com/skeema/skeema)を採用し�
 $ skeema diff local -p${MYSQL_ROOT_PASSWORD}
 ```
 
-- コードを DB に反映する
+- コードを DB に反映する(破壊的なら`--allow-unsafe`を付ける)
 
 ```
 $ skeema push local -p${MYSQL_ROOT_PASSWORD}

--- a/infrastructure/mysql/schemas/users.sql
+++ b/infrastructure/mysql/schemas/users.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `users` (
   `id` char(26) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザーULID',
   `name` varchar(255) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザー名',
-  `auth_token` char(60) COLLATE utf8mb4_bin NOT NULL COMMENT '認証トークンのハッシュ値',
+  `hashed_auth_token` char(60) COLLATE utf8mb4_bin NOT NULL COMMENT '認証トークンのハッシュ値',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='ユーザー';

--- a/infrastructure/mysql/schemas/users.sql
+++ b/infrastructure/mysql/schemas/users.sql
@@ -1,5 +1,6 @@
 CREATE TABLE `users` (
   `id` char(26) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザーULID',
   `name` varchar(255) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザー名',
+  `auth_token` char(60) COLLATE utf8mb4_bin NOT NULL COMMENT '認証トークンのハッシュ値',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='ユーザー';


### PR DESCRIPTION
## Issues
#23 

## About
認証用のauth_tokenカラムをmigration
## Background
有効期限があるsessionトークンを作成するために認証トークンが必要だから。
## Details
- ユーザテーブルに60文字固定長のauth_tokenカラムを追加する

- [UUID(v4)](https://github.com/google/uuid)でauth_tokenを作成予定。
- セキュリティ上、暗号化したデータをカラムに入れる
- 暗号化には[bcrypt](https://zenn.dev/kou_pg_0131/articles/go-digest-and-compare-by-bcrypt)を使用したい。
- `bcrypt#GenerateFromPassword`で60文字の暗号文字列ができる。(bcrypt内部でsaltも実装されている)
- `bcrypt#CompareHashAndPassword `で平文と比較できる

## Remarks
- 認証時はidとauthTokenをもらって、`User.find(id) -> CompareHashAndPassword`

## Preview
<img width="496" alt="スクリーンショット 2021-05-03 15 29 25" src="https://user-images.githubusercontent.com/38310693/116846908-5e8c8680-ac24-11eb-8c8e-83ffb54565f2.png">

<img width="780" alt="スクリーンショット 2021-05-03 15 22 21" src="https://user-images.githubusercontent.com/38310693/116846517-639d0600-ac23-11eb-9dfc-235e43a37fe8.png">
