### PR TITLE
feat: 独自エラーでgRPCのステータスコードを内包する

### DIFF
--- a/domain/model/user/entity.go
+++ b/domain/model/user/entity.go
@@ -1,7 +1,7 @@
 package user
 
 import (
-	"errors"
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 )
 
 type User struct {
@@ -12,13 +12,13 @@ type User struct {
 
 func New(id ID, name Name, hashedAuthToken HashedAuthToken) (User, error) {
 	if (id == ID{}) {
-		return User{}, errors.New("user id is nil")
+		return User{}, errors.Internal("user id is nil")
 	}
 	if name == "" {
-		return User{}, errors.New("user name is nil")
+		return User{}, errors.Internal("user name is nil")
 	}
 	if hashedAuthToken == nil {
-		return User{}, errors.New("user hashed_auth_token is nil")
+		return User{}, errors.Internal("user hashed_auth_token is nil")
 	}
 
 	return User{id, name, hashedAuthToken}, nil

--- a/domain/model/user/hashed_auth_token.go
+++ b/domain/model/user/hashed_auth_token.go
@@ -1,14 +1,12 @@
 package user
 
-import (
-	"errors"
-)
+import "github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 
 type HashedAuthToken []byte
 
 func NewHashedAuthToken(v []byte) (HashedAuthToken, error) {
 	if v == nil {
-		return nil, errors.New("user hashed_auth_token is nil")
+		return nil, errors.Internal("user hashed_auth_token is nil")
 	}
 
 	return HashedAuthToken(v), nil

--- a/domain/model/user/id.go
+++ b/domain/model/user/id.go
@@ -1,16 +1,16 @@
 package user
 
 import (
-	"errors"
-
 	"github.com/oklog/ulid/v2"
+
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 )
 
 type ID ulid.ULID
 
 func NewID(v ulid.ULID) (ID, error) {
 	if (v == ulid.ULID{}) {
-		return ID{}, errors.New("user id is nil")
+		return ID{}, errors.Internal("user id is nil")
 	}
 
 	return ID(v), nil

--- a/domain/model/user/name.go
+++ b/domain/model/user/name.go
@@ -1,9 +1,10 @@
 package user
 
 import (
-	"errors"
 	"fmt"
 	"unicode/utf8"
+
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 )
 
 type Name string
@@ -13,10 +14,12 @@ const NameMaxLen = 10
 
 func NewName(v string) (Name, error) {
 	if !utf8.ValidString(v) {
-		return "", errors.New("user name string is invalid")
+		return "", errors.InvalidArgument("user name string is invalid")
 	}
 	if utf8.RuneCountInString(v) < NameMinLen || utf8.RuneCountInString(v) > NameMaxLen {
-		return "", fmt.Errorf("user name should be %d to %d characters", NameMinLen, NameMaxLen)
+		return "", errors.InvalidArgument(
+			fmt.Sprintf("user name should be %d to %d characters", NameMinLen, NameMaxLen),
+		)
 	}
 
 	return Name(v), nil

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,16 @@
+package errors
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// InvalidArgument 400:BadRequest
+func InvalidArgument(v string) error {
+	return status.Error(codes.InvalidArgument, v)
+}
+
+// Internal 500:InternalError
+func Internal(v string) error {
+	return status.Error(codes.Internal, v)
+}

--- a/infrastructure/repository/user/impl.go
+++ b/infrastructure/repository/user/impl.go
@@ -4,6 +4,7 @@ import (
 	"gorm.io/gorm"
 
 	domain "github.com/CA22-game-creators/cookingbomb-apiserver/domain/model/user"
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 	dbModel "github.com/CA22-game-creators/cookingbomb-apiserver/infrastructure/mysql/model/user"
 )
 
@@ -19,5 +20,8 @@ func NewRepository(db *gorm.DB) domain.Repository {
 
 func (r repository) Save(entity domain.User) error {
 	user := dbModel.New(entity)
-	return r.db.Create(&user).Error
+	if err := r.db.Create(&user).Error; err != nil {
+		return errors.Internal(err.Error())
+	}
+	return nil
 }

--- a/test/domain/model/user/entity_test.go
+++ b/test/domain/model/user/entity_test.go
@@ -1,12 +1,12 @@
 package user_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/CA22-game-creators/cookingbomb-apiserver/domain/model/user"
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 
 	tdDomain "github.com/CA22-game-creators/cookingbomb-apiserver/test/testdata/domain/user"
 )
@@ -36,7 +36,7 @@ func TestNew(t *testing.T) {
 			input2:    tdDomain.Name,
 			input3:    tdDomain.HashedAuthToken,
 			expected1: user.User{},
-			expected2: errors.New("user id is nil"),
+			expected2: errors.Internal("user id is nil"),
 		},
 		{
 			title:     "【異常系】ユーザーアカウント名がzero値",
@@ -44,7 +44,7 @@ func TestNew(t *testing.T) {
 			input2:    "",
 			input3:    tdDomain.HashedAuthToken,
 			expected1: user.User{},
-			expected2: errors.New("user name is nil"),
+			expected2: errors.Internal("user name is nil"),
 		},
 		{
 			title:     "【異常系】認証トークンハッシュ値がzero値",
@@ -52,7 +52,7 @@ func TestNew(t *testing.T) {
 			input2:    tdDomain.Name,
 			input3:    nil,
 			expected1: user.User{},
-			expected2: errors.New("user hashed_auth_token is nil"),
+			expected2: errors.Internal("user hashed_auth_token is nil"),
 		},
 	}
 

--- a/test/domain/model/user/hashed_auth_token_test.go
+++ b/test/domain/model/user/hashed_auth_token_test.go
@@ -1,12 +1,12 @@
 package user_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/CA22-game-creators/cookingbomb-apiserver/domain/model/user"
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 
 	tdDomain "github.com/CA22-game-creators/cookingbomb-apiserver/test/testdata/domain/user"
 	tdString "github.com/CA22-game-creators/cookingbomb-apiserver/test/testdata/string/common"
@@ -31,7 +31,7 @@ func TestNewHashedAuthToken(t *testing.T) {
 			title:     "【異常系】認証トークンハッシュ値がzero値",
 			input:     nil,
 			expected1: nil,
-			expected2: errors.New("user hashed_auth_token is nil"),
+			expected2: errors.Internal("user hashed_auth_token is nil"),
 		},
 	}
 

--- a/test/domain/model/user/id_test.go
+++ b/test/domain/model/user/id_test.go
@@ -1,13 +1,13 @@
 package user_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/CA22-game-creators/cookingbomb-apiserver/domain/model/user"
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 
 	tdDomain "github.com/CA22-game-creators/cookingbomb-apiserver/test/testdata/domain/user"
 	tdString "github.com/CA22-game-creators/cookingbomb-apiserver/test/testdata/string/common"
@@ -32,7 +32,7 @@ func TestNewID(t *testing.T) {
 			title:     "【異常系】ULIDがzero値",
 			input:     ulid.ULID{},
 			expected1: user.ID{},
-			expected2: errors.New("user id is nil"),
+			expected2: errors.Internal("user id is nil"),
 		},
 	}
 

--- a/test/domain/model/user/name_test.go
+++ b/test/domain/model/user/name_test.go
@@ -1,13 +1,13 @@
 package user_test
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/CA22-game-creators/cookingbomb-apiserver/domain/model/user"
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 
 	tdDomain "github.com/CA22-game-creators/cookingbomb-apiserver/test/testdata/domain/user"
 	tdString "github.com/CA22-game-creators/cookingbomb-apiserver/test/testdata/string/user"
@@ -32,21 +32,23 @@ func TestNewName(t *testing.T) {
 			title:     "【異常系】ユーザー名がUTF-8でエンコードされた文字列ではない",
 			input:     tdString.Name.Invalid,
 			expected1: "",
-			expected2: errors.New("user name string is invalid"),
+			expected2: errors.InvalidArgument("user name string is invalid"),
 		},
 		{
 			title:     "【異常系】ユーザー名が長すぎる",
 			input:     tdString.Name.TooLong,
 			expected1: "",
-			expected2: fmt.Errorf(
-				"user name should be %d to %d characters", user.NameMinLen, user.NameMaxLen),
+			expected2: errors.InvalidArgument(
+				fmt.Sprintf("user name should be %d to %d characters", user.NameMinLen, user.NameMaxLen),
+			),
 		},
 		{
 			title:     "【異常系】ユーザー名が短すぎる",
 			input:     tdString.Name.TooShort,
 			expected1: "",
-			expected2: fmt.Errorf(
-				"user name should be %d to %d characters", user.NameMinLen, user.NameMaxLen),
+			expected2: errors.InvalidArgument(
+				fmt.Sprintf("user name should be %d to %d characters", user.NameMinLen, user.NameMaxLen),
+			),
 		},
 	}
 

--- a/test/errros/errors_test.go
+++ b/test/errros/errors_test.go
@@ -1,0 +1,67 @@
+package errors_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
+)
+
+func TestInvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title    string
+		input    string
+		expected error
+	}{
+		{
+			title:    "【正常系】バッドリクエスト(InvalidArgument)エラーを作成できる",
+			input:    "error",
+			expected: status.Error(codes.InvalidArgument, "error"),
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+
+		t.Run("InvalidArgument:"+td.title, func(t *testing.T) {
+			t.Parallel()
+
+			output := errors.InvalidArgument(td.input)
+
+			assert.Equal(t, td.expected, output)
+		})
+	}
+}
+
+func TestInternal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title    string
+		input    string
+		expected error
+	}{
+		{
+			title:    "【正常系】インターナルサーバー(Internal)エラーを作成できる",
+			input:    "error",
+			expected: status.Error(codes.Internal, "error"),
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+
+		t.Run("Internal:"+td.title, func(t *testing.T) {
+			t.Parallel()
+
+			output := errors.Internal(td.input)
+
+			assert.Equal(t, td.expected, output)
+		})
+	}
+}

--- a/util/crypto_manager.go
+++ b/util/crypto_manager.go
@@ -2,6 +2,7 @@
 package util
 
 import (
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -16,5 +17,6 @@ func NewCryptManager() CryptoManager {
 }
 
 func (cryptoManager) Encrypt(v string) ([]byte, error) {
-	return bcrypt.GenerateFromPassword([]byte(v), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(v), bcrypt.DefaultCost)
+	return hash, errors.Internal(err.Error())
 }

--- a/util/id_generator.go
+++ b/util/id_generator.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 )
 
 type idGenerator struct{}
@@ -19,6 +21,6 @@ func NewIDGenerator() IDGenerator {
 }
 
 func (idGenerator) Generate() (ulid.ULID, error) {
-	t := time.Unix(1000000, 0)
-	return ulid.New(ulid.Timestamp(t), rand.Reader)
+	id, err := ulid.New(ulid.Timestamp(time.Unix(1000000, 0)), rand.Reader)
+	return id, errors.Internal(err.Error())
 }

--- a/util/token_generator.go
+++ b/util/token_generator.go
@@ -3,6 +3,8 @@ package util
 
 import (
 	"github.com/google/uuid"
+
+	"github.com/CA22-game-creators/cookingbomb-apiserver/errors"
 )
 
 type tokenGenerator struct{}
@@ -16,5 +18,6 @@ func NewTokenGenerator() TokenGenerator {
 }
 
 func (tokenGenerator) Generate() (uuid.UUID, error) {
-	return uuid.NewRandom()
+	token, err := uuid.NewRandom()
+	return token, errors.Internal(err.Error())
 }


### PR DESCRIPTION
## Issues
#30 
## About
独自エラーでgRPCのステータスコードを内包する
## Background
- 400系、500系など、エラーごとにステータスを持たせたかったので
## Details
- ユーザー入力依存のバリデーションエラーは400系のInvalidArgumentで処理
- サーバー側のエラーは500系のInternalで処理
- [gRPCステータスコード一覧](https://qiita.com/Hiraku/items/0549e4cf7079d22b27e8)

## Remarks
- DBからunique違反とか返ってくる可能性があるが、重複チェックなどは(ID/Tokenなどの例外を除いて)DB入力の前に済ませておく前提なので、500系のみ返す。

## Preview
エラー文は以下のように出力される。
clientはこれをParseしてcodeを判断することになりそう？
```
rpc error: code = InvalidArgument desc = ${error text}
```