### PR TITLE
feat: セッション用DB作成

### DIFF
--- a/infrastructure/mysql/schemas/.skeema
+++ b/infrastructure/mysql/schemas/.skeema
@@ -1,6 +1,6 @@
 default-character-set=utf8mb4
 default-collation=utf8mb4_bin
-generator=skeema:1.5.0-community
+generator=skeema:1.5.1-community
 schema=cooking_bomb
 
 [local]

--- a/infrastructure/mysql/schemas/sessions.sql
+++ b/infrastructure/mysql/schemas/sessions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `sessions` (
+  `user_id` char(26) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザーID',
+  `session_token` char(36) COLLATE utf8mb4_bin NOT NULL COMMENT 'セッショントークン',
+  `expired_at` datetime NOT NULL COMMENT 'セッションの有効期限',
+  PRIMARY KEY (`user_id`),
+  CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='セッション';

--- a/infrastructure/mysql/schemas/sessions.sql
+++ b/infrastructure/mysql/schemas/sessions.sql
@@ -3,5 +3,6 @@ CREATE TABLE `sessions` (
   `session_token` char(36) COLLATE utf8mb4_bin NOT NULL COMMENT 'セッショントークン',
   `expired_at` datetime NOT NULL COMMENT 'セッションの有効期限',
   PRIMARY KEY (`user_id`),
-  CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+  UNIQUE KEY `uk_sessions_session_token` (`session_token`),
+  CONSTRAINT `fk_sessions_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='セッション';


### PR DESCRIPTION
## Issues
#33 
## About
セッション用DB作成
## Background
認証のためにセッショントークン・有効期限を管理したいため
## Details
- ユーザーテーブルに紐づくセッションテーブルを作成
-  外部キー制約で紐づくユーザーが削除されたらセッションレコードも削除される
- `session_token`は暗号化されていないUUIDなので`cha(36)`で、`user_id`はULIDなので`char(26)`
※uuidは予測困難性に優れているためトークンに採用し、ulidはソートできるなどの利点からUserIDに採用
## Preview
```
$ make migrate
$  show full columns from sessions; (in mysql)
```
<img width="1118" alt="スクリーンショット 2021-05-12 12 02 12" src="https://user-images.githubusercontent.com/38310693/117912142-e441bd80-b319-11eb-9bce-ddb736ff8d9d.png">

