### PR TITLE
refactor: 非推奨になったgolintを外す

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -23,7 +23,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         version: v1.29
-        args: --enable=golint,gosec,prealloc,gocognit
+        args: --enable=gosec,prealloc,gocognit
 
     - name: Run test
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ migrate:
 .PHONY: lint
 lint:
 	go mod tidy
-	golangci-lint run --enable=golint,gosec,prealloc,gocognit
+	golangci-lint run --enable=gosec,prealloc,gocognit
 
 .PHONY: test
 test:


### PR DESCRIPTION
## Issues
#36 

## About
非推奨になったgolintを外す
## Background
[golintが非推奨になった](https://zenn.dev/sanpo_shiho/articles/09d1da9af91998)
## Details
- githubActionと、make lintから外す
## Preview

before
<img width="1439" alt="スクリーンショット 2021-05-18 2 38 04" src="https://user-images.githubusercontent.com/38310693/118532582-13c15180-b782-11eb-828a-f25d459fd278.png">

after
<img width="422" alt="スクリーンショット 2021-05-18 2 38 20" src="https://user-images.githubusercontent.com/38310693/118532603-1d4ab980-b782-11eb-9472-27285074e495.png">
