### PR TITLE
fix: ID/Token生成・暗号化のエラーがない時にぬるぽになる

### DIFF
--- a/util/crypto_manager.go
+++ b/util/crypto_manager.go
@@ -18,5 +18,8 @@ func NewCryptManager() CryptoManager {
 
 func (cryptoManager) Encrypt(v string) ([]byte, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(v), bcrypt.DefaultCost)
-	return hash, errors.Internal(err.Error())
+	if err != nil {
+		return []byte{}, errors.Internal(err.Error())
+	}
+	return hash, nil
 }

--- a/util/id_generator.go
+++ b/util/id_generator.go
@@ -22,5 +22,8 @@ func NewIDGenerator() IDGenerator {
 
 func (idGenerator) Generate() (ulid.ULID, error) {
 	id, err := ulid.New(ulid.Timestamp(time.Unix(1000000, 0)), rand.Reader)
-	return id, errors.Internal(err.Error())
+	if err != nil {
+		return ulid.ULID{}, errors.Internal(err.Error())
+	}
+	return id, nil
 }

--- a/util/token_generator.go
+++ b/util/token_generator.go
@@ -19,5 +19,8 @@ func NewTokenGenerator() TokenGenerator {
 
 func (tokenGenerator) Generate() (uuid.UUID, error) {
 	token, err := uuid.NewRandom()
-	return token, errors.Internal(err.Error())
+	if err != nil {
+		return uuid.Nil, errors.Internal(err.Error())
+	}
+	return token, nil
 }


### PR DESCRIPTION
## Issues
NaN
## About
ID/Token生成・暗号化のエラーがない時にぬるぽになる
## Background
以下の不具合調査
https://github.com/CA22-game-creators/cookingbomb-apiserver/pull/38
## Details
errorがnilの時も独自エラーに変換してへんきゃくしていた。
