### PR TITLE
feat: apiにバリデーションを実装する

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CA22-game-creators/cookingbomb-apiserver
 go 1.16
 
 require (
-	github.com/CA22-game-creators/cookingbomb-proto v0.1.9
+	github.com/CA22-game-creators/cookingbomb-proto v0.1.10
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/golang/mock v1.4.4
 	github.com/golangci/golangci-lint v1.40.1

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CA22-game-creators/cookingbomb-proto v0.1.9 h1:zRgQbEGfUVl7P8SlYeNgl++2P7ZHsq4Yg5uW/7rWGFQ=
-github.com/CA22-game-creators/cookingbomb-proto v0.1.9/go.mod h1:VaFJFX7sHbIck8b4b2k8wCg75uyvXJ8+GrybhAfG1RM=
+github.com/CA22-game-creators/cookingbomb-proto v0.1.10 h1:al6XosYwiQt7I7UuVZzxMAeM/Bb67Hi4A8OAMUeSU2M=
+github.com/CA22-game-creators/cookingbomb-proto v0.1.10/go.mod h1:Z1YR2OqCa/nbCdSdAYurz3XYZeh8zGicpk2J2RyHfyo=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rWPdisA5ynNEsoARbiCBOyGcJM4/OzsM=

--- a/presentation/account/controller.go
+++ b/presentation/account/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	pb "github.com/CA22-game-creators/cookingbomb-proto/server/pb/api"
+	validator "github.com/CA22-game-creators/cookingbomb-proto/server/validation"
 	"github.com/oklog/ulid/v2"
 
 	getAccountInfo "github.com/CA22-game-creators/cookingbomb-apiserver/application/usecase/account/get_account_info"
@@ -26,8 +27,11 @@ func New(su signup.InputPort, gs refreshSessionToken.InputPort, ga getAccountInf
 }
 
 func (c controller) Signup(ctx context.Context, request *pb.SignupRequest) (*pb.SignupResponse, error) {
-	input := signup.InputData{Name: request.Name}
+	if err := validator.Validate(request); err != nil {
+		return nil, err
+	}
 
+	input := signup.InputData{Name: request.Name}
 	output := c.signup.Handle(input)
 	if output.Err != nil {
 		return nil, output.Err
@@ -43,8 +47,11 @@ func (c controller) Signup(ctx context.Context, request *pb.SignupRequest) (*pb.
 }
 
 func (c controller) GetSessionToken(ctx context.Context, request *pb.GetSessionTokenRequest) (*pb.GetSessionTokenResponse, error) {
-	input := refreshSessionToken.InputData{UserID: request.UserId, AuthToken: request.AuthToken}
+	if err := validator.Validate(request); err != nil {
+		return nil, err
+	}
 
+	input := refreshSessionToken.InputData{UserID: request.UserId, AuthToken: request.AuthToken}
 	output := c.refreshSessionToken.Handle(input)
 	if output.Err != nil {
 		return nil, output.Err
@@ -56,8 +63,11 @@ func (c controller) GetSessionToken(ctx context.Context, request *pb.GetSessionT
 }
 
 func (c controller) GetAccountInfo(ctx context.Context, request *pb.GetAccountInfoRequest) (*pb.GetAccountInfoResponse, error) {
-	input := getAccountInfo.InputData{SessionToken: request.SessionToken}
+	if err := validator.Validate(request); err != nil {
+		return nil, err
+	}
 
+	input := getAccountInfo.InputData{SessionToken: request.SessionToken}
 	output := c.getAccountInfo.Handle(input)
 	if output.Err != nil {
 		return nil, output.Err


### PR DESCRIPTION
## Issues
resolve #40 
## About
apiにバリデーションを実装する
## Background
protoで実装したバリデーションを実用化
## Details
- protoをv0.1.10に
- controllerの処理前にバリデーションメソッド追加

## Preview
<img width="977" alt="スクリーンショット 2021-06-20 0 25 32" src="https://user-images.githubusercontent.com/38310693/122647211-0969ed00-d15e-11eb-9175-6eafc48965bd.png">


