### PR TITLE
Dockerのネットワークを指定

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ test:
 generate:
 	rm -rf mock/
 	go generate ./...
+
+.PHONY: build-env
+initialize:
+	if [ `docker network ls | grep shared-local |wc -l` -eq 0 ]; then docker network create shared-local; fi

--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,5 @@ generate:
 	go generate ./...
 
 .PHONY: build-env
-initialize:
+build-env:
 	if [ `docker network ls | grep shared-local |wc -l` -eq 0 ]; then docker network create shared-local; fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - "8080:8080"
     depends_on:
       - mysql
+    networks: 
+      - "shared-local"
 
   mysql:
     image: mysql:8.0
@@ -34,3 +36,9 @@ services:
     restart: always
     ports:
       - "13306:3306"
+    networks:
+      - "shared-local"
+
+networks: 
+  shared-local:
+    external: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,14 @@
 
 Docker を[ここ](https://www.docker.com/get-started)からインストール
 
+## 環境準備
+
+各環境ごとに、一度のみ実行する必要があります。
+
+```
+make build-env
+```
+
 ## アプリケーションの実行
 
 ```


### PR DESCRIPTION
## About

- docker-composeファイルを変更、使用するネットワークを`shared-local`に指定

```yml
version: "3"
services:
  app:
    : 
    depends_on:
      - mysql
    networks: 
      - "shared-local"

  mysql:
    image: mysql:8.0
    : 
    ports:
      - "13306:3306"
    networks:
      - "shared-local"

networks: 
  shared-local:
    external: true
```

- 環境構築用のmakeコマンドを整備

```sh
.PHONY: build-env
build-env:
	if [ `docker network ls | grep shared-local |wc -l` -eq 0 ]; then docker network create shared-local; fi
```

- ドキュメントに追記

```md
## 環境準備

各環境ごとに、一度のみ実行する必要があります。

\```
make build-env
\```
```

## Background
docker-composeは、１つのファイルごとに(ファイル単位をプロジェクトと呼ぶ)共通のブリッジネットワークを用いてコンテナを作成する。
従って、複数のプロジェクト間でコンテナを作成する際、コンテナ間通信を実現するためには、それぞれのコンテナが同一のブリッジネットワーク上にいるよう指定する必要がある。

https://knowledge.sakura.ad.jp/23899/

## Details
Aboutを参照

## Remarks

build-envでシェル芸じみたことをしているが、要するに`shared-local`が無ければ作成している。

## Preview